### PR TITLE
Use a failable initializer for Report

### DIFF
--- a/Sources/GitVersion/Report+Git.swift
+++ b/Sources/GitVersion/Report+Git.swift
@@ -9,14 +9,18 @@ import Foundation
 import GitLibrary
 
 extension Report {
-  static func create(state: RepositoryState, tag: String? = nil, branch: String? = nil) -> Report {
+  static func create(state: RepositoryState, tag: String? = nil, branch: String? = nil) -> Report? {
     let nonEmptyTag = (tag != nil && tag!.isEmpty) ? nil : tag
-    return Report(state: state, name: (nonEmptyTag != nil) ? nonEmptyTag : branch)
+    guard let report = Report(state: state, name: (nonEmptyTag != nil) ? nonEmptyTag : branch)
+    else {
+      return nil
+    }
+    return report
   }
 }
 
 extension Report {
-  static func create(from git: Git) async -> Report {
+  static func create(from git: Git) async -> Report? {
     var state: RepositoryState = .invalid
     do {
       state = try await git.status().isEmpty ? .noChanges : .localChanges

--- a/Sources/GitVersion/Report.swift
+++ b/Sources/GitVersion/Report.swift
@@ -10,17 +10,17 @@ import Foundation
 private let Local = "local"
 
 enum Report: CustomStringConvertible {
-  init(state: RepositoryState, name: String?) {
+  init?(state: RepositoryState, name: String?) {
     let nonEmptyName = (name != nil && name!.isEmpty) ? nil : name?.firstLine
     switch state {
     case .invalid:
       self = .notGit
     case .localChanges:
-      let name = (nonEmptyName != nil) ? nonEmptyName! : Local
-      self = .localChanges(name)
+      guard let nonEmptyName else { return nil }
+      self = .localChanges(nonEmptyName)
     case .noChanges:
-      let name = (nonEmptyName != nil) ? nonEmptyName! : "version"
-      self = .noChanges(name)
+      guard let nonEmptyName else { return nil }
+      self = .noChanges(nonEmptyName)
     }
   }
 

--- a/Tests/GitVersion/ReportGitTest.swift
+++ b/Tests/GitVersion/ReportGitTest.swift
@@ -12,18 +12,25 @@ import Testing
 
 struct ReportGitTest {
   @Test func state_tag() throws {
-    #expect("\(Report.create(state: .noChanges, tag: "name"))" == "name")
+    #expect(try #require(Report.create(state: .noChanges, tag: "name")).description == "name")
   }
 
   @Test func state_branch() throws {
-    #expect("\(Report.create(state: .noChanges, tag: "tag", branch: "branch"))" == "tag")
-    #expect("\(Report.create(state: .noChanges, tag: nil, branch: "branch"))" == "branch")
-    #expect("\(Report.create(state: .noChanges, tag: "", branch: "branch"))" == "branch")
+    #expect(
+      try #require(Report.create(state: .noChanges, tag: "tag", branch: "branch")).description
+        == "tag")
+    #expect(
+      try #require(Report.create(state: .noChanges, tag: nil, branch: "branch")).description
+        == "branch")
+    #expect(
+      try #require(Report.create(state: .noChanges, tag: "", branch: "branch")).description
+        == "branch")
   }
 
   @Test func state_branchEmpty() throws {
-    #expect("\(Report.create(state: .noChanges, tag: "tag", branch: ""))" == "tag")
-    #expect("\(Report.create(state: .noChanges, tag: nil, branch: ""))" == "version")
-    #expect("\(Report.create(state: .noChanges, tag: "", branch: ""))" == "version")
+    #expect(
+      try #require(Report.create(state: .noChanges, tag: "tag", branch: "")).description == "tag")
+    #expect(Report.create(state: .noChanges, tag: nil, branch: "") == nil)
+    #expect(Report.create(state: .noChanges, tag: "", branch: "") == nil)
   }
 }

--- a/Tests/GitVersion/ReportTest.swift
+++ b/Tests/GitVersion/ReportTest.swift
@@ -12,24 +12,24 @@ import Testing
 
 struct ReportTest {
   @Test func state_noName() throws {
-    #expect("\(Report(state: .invalid, name: nil))" == "unknown")
-    #expect("\(Report(state: .localChanges, name: nil))" == "local")
-    #expect("\(Report(state: .noChanges, name: nil))" == "version")
+    #expect(try #require(Report(state: .invalid, name: nil)).description == "unknown")
+    #expect(Report(state: .localChanges, name: nil) == nil)
+    #expect(Report(state: .noChanges, name: nil) == nil)
   }
 
   @Test func state_emptyName() throws {
-    #expect("\(Report(state: .invalid, name: ""))" == "unknown")
-    #expect("\(Report(state: .localChanges, name: ""))" == "local")
-    #expect("\(Report(state: .noChanges, name: ""))" == "version")
+    #expect(try #require(Report(state: .invalid, name: "")).description == "unknown")
+    #expect(Report(state: .localChanges, name: "") == nil)
+    #expect(Report(state: .noChanges, name: "") == nil)
   }
 
   @Test func state_name() throws {
-    #expect("\(Report(state: .invalid, name: "name"))" == "unknown")
-    #expect("\(Report(state: .localChanges, name: "name"))" == "name-local")
-    #expect("\(Report(state: .noChanges, name: "name"))" == "name")
+    #expect(try #require(Report(state: .invalid, name: "name")).description == "unknown")
+    #expect(try #require(Report(state: .localChanges, name: "name")).description == "name-local")
+    #expect(try #require(Report(state: .noChanges, name: "name")).description == "name")
   }
 
   @Test func state_funkyName() throws {
-    #expect("\(Report(state: .noChanges, name: "name\ntwo"))" == "name")
+    #expect(try #require(Report(state: .noChanges, name: "name\ntwo")).description == "name")
   }
 }


### PR DESCRIPTION
- makes it much harder to create a bogus Report, and "canned" values are eliminated.