### PR TITLE
Add --variable option

### DIFF
--- a/Sources/GitVersion/GitVersionTool.swift
+++ b/Sources/GitVersion/GitVersionTool.swift
@@ -32,6 +32,10 @@ public struct GitVersionTool: AsyncParsableCommand {
   )
   var gitDirectory: URL
 
+  /// Optional variableName to use for swift code.
+  @Option(help: "The variable name to use to generate Swift source code.")
+  var variable: String?
+
   public func run() async throws {
     #if DEBUG
       let suppressStandardErr = false
@@ -39,11 +43,7 @@ public struct GitVersionTool: AsyncParsableCommand {
       let suppressStandarErr = true
     #endif
     let git = Git(directory: gitDirectory, suppressStandardErr: suppressStandardErr)
-    guard let report = await Report.create(from: git) else {
-      print("#error")
-      return
-    }
-    print(report)
+    print(await Report.emit(reportable: git, variable: variable))
   }
 
   public init() {}  // This is public and empty to help the compiler.

--- a/Sources/GitVersion/Report+SourceCode.swift
+++ b/Sources/GitVersion/Report+SourceCode.swift
@@ -1,0 +1,27 @@
+//
+//  Report+SourceCode.swift
+//  GitVersion
+//
+//  Created by Greg Bolsinga on 12/18/24.
+//
+
+import Foundation
+import GitLibrary
+
+extension Report {
+  static func emit<T: Reportable>(reportable: T, variable: String?) async -> String {
+    if let report = await Self.create(from: reportable) {
+      if let variable {
+        return variable.sourceCode(value: report.description)
+      } else {
+        return report.description
+      }
+    } else {
+      if let variable {
+        return variable.errorSourceCode
+      } else {
+        return SourceCodeError
+      }
+    }
+  }
+}

--- a/Sources/GitVersion/String+SourceCode.swift
+++ b/Sources/GitVersion/String+SourceCode.swift
@@ -1,0 +1,20 @@
+//
+//  String+SourceCode.swift
+//  GitVersion
+//
+//  Created by Greg Bolsinga on 12/18/24.
+//
+
+import Foundation
+
+let SourceCodeError = "#error"
+
+extension String {
+  func sourceCode(value: String) -> String {
+    "let \(self) = \"\(value)\""
+  }
+
+  var errorSourceCode: String {
+    "let \(self) = \(SourceCodeError)"
+  }
+}

--- a/Tests/GitVersion/ReportEmitTest.swift
+++ b/Tests/GitVersion/ReportEmitTest.swift
@@ -1,0 +1,45 @@
+//
+//  ReportEmitTest.swift
+//  GitVersion
+//
+//  Created by Greg Bolsinga on 12/18/24.
+//
+
+import Testing
+
+@testable import GitVersion
+
+private struct EmitTestReportable: Reportable {
+  let state: RepositoryState
+  let tag: String?
+
+  internal init(state: RepositoryState, tag: String? = nil) {
+    self.state = state
+    self.tag = tag
+  }
+
+  func state() async -> RepositoryState { state }
+  func tag() async -> String? { tag }
+  func branch() async -> String? { nil }
+  func commit() async -> String? { nil }
+}
+
+struct ReportEmitTest {
+  @Test func emit() async throws {
+    #expect(
+      await Report.emit(reportable: EmitTestReportable(state: .invalid), variable: nil) == "#error")
+    #expect(
+      await Report.emit(reportable: EmitTestReportable(state: .invalid), variable: "variable")
+        == "let variable = #error")
+    #expect(
+      await Report.emit(reportable: EmitTestReportable(state: .noChanges), variable: nil)
+        == "#error")
+    #expect(
+      await Report.emit(
+        reportable: EmitTestReportable(state: .noChanges, tag: "name"), variable: nil) == "name")
+    #expect(
+      await Report.emit(
+        reportable: EmitTestReportable(state: .noChanges, tag: "name"), variable: "variable")
+        == "let variable = \"name\"")
+  }
+}


### PR DESCRIPTION
- it will print out a Swift code statement `let variable = name`, otherwise just name.
- if there is an issue getting the Report, it will emit source code that will not compile.